### PR TITLE
Bump better theme version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Sphinx==1.6.5
-sphinx-better-theme==0.13
+sphinx-better-theme==0.15


### PR DESCRIPTION
The docs are failing to build because the theme dependency is set to an older version:

![battlerite-docs-build-error](https://user-images.githubusercontent.com/20918809/40117097-db1f3e6e-58e3-11e8-9642-725113afc922.PNG)

Current version of the better theme is 1.5 as seen here: https://pypi.org/project/sphinx-better-theme/